### PR TITLE
better persona separation of credential definitions for holder/issuer

### DIFF
--- a/src/renderer/components/AgentBase.vue
+++ b/src/renderer/components/AgentBase.vue
@@ -180,8 +180,9 @@
                 @schema-refresh="getSchemas"></agent-schema-list>
               <agent-cred-def-list
                 title="Credential Definitions"
+                v-bind:retrievable="false"
                 v-bind:can_create="true"
-                v-bind:list="cred_defs"
+                v-bind:list="issuerCredDefs"
                 v-bind:schemas="schemas"
                 @cred-def-send="publishCredDef"
                 @cred-def-get="getCredentialDefinition"></agent-cred-def-list>
@@ -199,15 +200,16 @@
             <el-row>
               <agent-cred-def-list
                 title="Retrieved Credential Definitions"
+                v-bind:retrievable="true"
                 v-bind:can_create="false"
-                v-bind:list="cred_defs"
+                v-bind:list="proposalCredDefs"
                 v-bind:schemas="schemas"
                 @cred-def-get="getCredentialDefinition"></agent-cred-def-list>
               <agent-my-credentials-list
                 title="Credentials"
                 editable="false"
                 v-bind:credentials="holder_credentials"
-                v-bind:cred_defs="cred_defs"
+                v-bind:cred_defs="proposalCredDefs"
                 v-bind:connections="activeConnections"
                 @cred-refresh="getHoldersCredentials"
                 @propose="sendCredentialProposal"></agent-my-credentials-list>
@@ -1309,15 +1311,15 @@ export default {
       return Object.values(this.connections).filter(conn => "state" in conn && conn.state === "error")
     },
     // ---------------------- Credential Definition Filters --------------------      
-    issuerCredDefs() {
-      return Object.values(this.cred_defs).filter(
-        cred_def => cred_def.author == "self" || cred_def.cred_def_id.split(':', 2)[0] === this.public_did
-      );
-    },
     /* credentialDefinition(){
         return this.cred_defs.filter(cred => "state" in cred && cred.state === "offer_sent")
       }, */
     // ---------------------- Issuer Credential Filters --------------------      
+    issuerCredDefs() {
+      return Object.values(this.cred_defs).filter(
+        cred_def => cred_def.author === "self" || cred_def.cred_def_id.split(':', 2)[0] === this.public_did
+      );
+    },
     issuerOfferSentStateCredentials(){
       return this.issuer_credentials.filter(cred => "state" in cred && cred.state === "offer_sent")
     },
@@ -1331,6 +1333,11 @@ export default {
       return this.issuer_credentials.filter(cred => "state" in cred && cred.state === "stored")
     },
     // ---------------------- Holder Credential Filters --------------------      
+    proposalCredDefs() {
+      return Object.values(this.cred_defs).filter(
+        cred_def => cred_def.author !== "self" || cred_def.cred_def_id.split(':', 2)[0] !== this.public_did
+      );
+    },
     holderOfferReceivedStateCredentials(){
       return this.holder_credentials.filter(cred => "state" in cred && cred.state === "offer_received")
     },

--- a/src/renderer/components/AgentCredDefList.vue
+++ b/src/renderer/components/AgentCredDefList.vue
@@ -3,15 +3,16 @@
     <nav class="navbar navbar-expand-lg navbar-light bg-light">
       <a class="navbar-brand" href="#">{{ title }}</a>
       <el-input
+        v-if="retrievable"
         v-model="retrieve_cred_def_id"
         style="width: 300px;">
-        <el-button
+        <el-button 
           slot="append"
           icon="el-icon-search"
           @click="retrieve">Retrieve</el-button>
       </el-input>
       <el-button
-        v-if="can_create"
+        v-if="can_create && list"
         type="primary"
         icon="el-icon-plus"
         @click="createFormActive = true">Create</el-button>
@@ -64,7 +65,7 @@ import VueJsonPretty from 'vue-json-pretty';
 
 export default {
   name: 'agent-cred-def-list',
-  props: ['title', 'list', 'can_create', 'schemas'],
+  props: ['retrievable','title', 'list', 'can_create', 'schemas'],
   components: {
     VueJsonPretty,
   },


### PR DESCRIPTION
before it was easy to assume you could resolve a credential definition from the ledger and then be able to issue credentials with the public parts from the ledger. 
Signed-off-by: Adam Burdett <burdettadam@gmail.com>